### PR TITLE
client: Fix connect spec

### DIFF
--- a/src/grpc_client.erl
+++ b/src/grpc_client.erl
@@ -140,7 +140,7 @@ connect(Transport, Host, Port) ->
 -spec connect(Transport::tcp|ssl,
               Host::string(),
               Port::integer(),
-              Options::[connection_option()]) -> {ok, connection()}.
+              Options::[connection_option()]) -> {ok, connection()} | {error, term()}.
 %% @doc Start a connection to a gRPC server.
 %%
 %% If 'verify_server_identity' is true (and Transport == ssl), the client will

--- a/src/grpc_client_connection.erl
+++ b/src/grpc_client_connection.erl
@@ -50,7 +50,7 @@
 -spec new(Transport::tcp|ssl,
           Host::string(),
           Port::integer(),
-          Options::[connection_option()]) -> {ok, connection()}.
+          Options::[connection_option()]) -> {ok, connection()} | {error, term()}.
 %% @doc Open a new http/2 connection and check authorisation.
 new(Transport, Host, Port, Options) ->
     {GrpcOptions, H2Options} = process_options(Options, Transport),


### PR DESCRIPTION
Errors can happen, update the spec to accommodate. 

Match the [spec from http2_lib](https://github.com/Bluehouse-Technology/http2_client/blob/8a6faf3ef1e0f3bb480d52d34ef5181258e99302/src/http2_client.erl#L267-L275)